### PR TITLE
feat(ui): add URL query parameter support for CLI/GUI mode switching

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import { Suspense } from "react";
 import "./globals.css";
 import { ThemeProvider, InterfaceModeProvider } from "@/providers";
 import { METADATA } from "@/constants";
@@ -20,9 +21,11 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} font-sans antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem={true}>
-          <InterfaceModeProvider>
-            {children}
-          </InterfaceModeProvider>
+          <Suspense fallback={null}>
+            <InterfaceModeProvider>
+              {children}
+            </InterfaceModeProvider>
+          </Suspense>
         </ThemeProvider>
       </body>
     </html>

--- a/providers/interface-mode-provider.tsx
+++ b/providers/interface-mode-provider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { createContext, useContext, useState, ReactNode } from "react";
+import { createContext, useContext, useState, useEffect, ReactNode, useCallback } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
 
 interface InterfaceModeContextType {
   isCLI: boolean;
@@ -14,7 +15,50 @@ interface InterfaceModeProviderProps {
 }
 
 export function InterfaceModeProvider({ children }: InterfaceModeProviderProps) {
-  const [isCLI, setIsCLI] = useState(false);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  
+  // Initialize from URL query parameter or default to false
+  const [isCLI, setIsCLIState] = useState(() => {
+    const mode = searchParams.get("mode");
+    return mode === "cli";
+  });
+
+  // Update URL when mode changes
+  const setIsCLI = useCallback(
+    (value: boolean) => {
+      setIsCLIState(value);
+      
+      const params = new URLSearchParams(searchParams.toString());
+      
+      if (value) {
+        params.set("mode", "cli");
+      } else {
+        params.delete("mode");
+      }
+      
+      // Use push to add to browser history for shareable URLs
+      const newUrl = params.toString() 
+        ? `${pathname}?${params.toString()}` 
+        : pathname;
+      
+      router.push(newUrl, { scroll: false });
+    },
+    [searchParams, pathname, router]
+  );
+
+  // Sync with URL changes (browser back/forward and initial load)
+  useEffect(() => {
+    const mode = searchParams.get("mode");
+    const shouldBeCLI = mode === "cli";
+    
+    // Only update if different to avoid unnecessary re-renders
+    if (shouldBeCLI !== isCLI) {
+      setIsCLIState(shouldBeCLI);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]); // Only sync when URL changes, not when state changes
 
   return (
     <InterfaceModeContext.Provider value={{ isCLI, setIsCLI }}>


### PR DESCRIPTION
- Add ?mode=cli query parameter support for shareable CLI mode URLs
- Update InterfaceModeProvider to sync with URL query parameters
- Initialize mode from URL on page load
- Update URL when mode changes programmatically
- Support browser back/forward navigation between modes
- Wrap InterfaceModeProvider with Suspense for useSearchParams compatibility
- Preserve existing state-based switching functionality

Benefits:
- Shareable URLs: users can link directly to CLI mode
- Browser history: back/forward buttons work correctly
- SEO-friendly: URL reflects current interface mode
- No breaking changes: all existing functionality preserved
