### PR TITLE
fix: make open command case-insensitive for github and linkedin

### DIFF
--- a/components/features/cli/commands/open.ts
+++ b/components/features/cli/commands/open.ts
@@ -26,9 +26,9 @@ export const openCommand: Command = {
           error: "Resume URL not configured",
         };
       }
-    } else if (input === "github" || input === "gh") {
+    } else if (input.toLowerCase() === "github" || input.toLowerCase() === "gh") {
       url = SOCIAL_LINKS.github;
-    } else if (input === "linkedin" || input === "li") {
+    } else if (input.toLowerCase() === "linkedin" || input.toLowerCase() === "li") {
       url = SOCIAL_LINKS.linkedin;
     } else {
       // Check if it's a project name


### PR DESCRIPTION
Fix issue #12: The open command now correctly handles case-insensitive
inputs for 'github'/'gh' and 'linkedin'/'li', matching the behavior of
the 'resume' check.

Previously, inputs like 'open GitHub' or 'open LinkedIn' would fail
to match and fall through to the fallback logic, producing incorrect
URLs like 'https://Github' instead of the correct social media URLs.

Changes:
- Use input.toLowerCase() for github/gh checks (consistent with resume)
- Use input.toLowerCase() for linkedin/li checks (consistent with resume)

This ensures all variations (GitHub, GITHUB, github, etc.) work correctly.
