### PR TITLE
fix: prevent CLI input auto-focus on interactive elements and output area

### DIFF
--- a/components/features/cli/terminal-input.tsx
+++ b/components/features/cli/terminal-input.tsx
@@ -20,9 +20,26 @@ export const TerminalInput = ({
   const [historyIndex, setHistoryIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Focus input on mount and when clicking in terminal area
+  // Focus input on mount and when clicking in terminal area (but not on output or interactive elements)
   useEffect(() => {
-    const handleClick = () => {
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      
+      // Don't focus if clicking on:
+      // 1. Links (allow navigation)
+      // 2. Buttons (allow button actions)
+      // 3. Inputs/textareas (allow editing other inputs)
+      // 4. Terminal output area (allow text selection and scrolling)
+      const isLink = target.tagName === 'A' || target.closest('a');
+      const isButton = target.tagName === 'BUTTON' || target.closest('button');
+      const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA';
+      const isInOutput = target.closest('.terminal-output') !== null;
+      
+      if (isLink || isButton || isInput || isInOutput) {
+        return;
+      }
+      
+      // Focus input for clicks on terminal window container (not output)
       inputRef.current?.focus();
     };
 


### PR DESCRIPTION
Fix issue #14: The CLI input no longer steals focus when clicking on
links, buttons, scrollbars, or when trying to select/copy text from
the terminal output area.

Previously, a document-level click listener focused the input on ANY
click, which was disruptive when users tried to:
- Click links in the output
- Click buttons (like the exit button)
- Select/copy text from the output
- Use the scrollbar

Changes:
- Added checks to skip focusing when clicking on links, buttons,
  inputs/textareas, or elements within the terminal output area
- Input now only focuses when clicking on the terminal window
  container itself (not the output area)

This preserves the intended auto-focus behavior while allowing proper
interaction with output content and interactive elements.
