### PR TITLE
fix: improve terminal height handling

### DIFF
--- a/components/features/cli/terminal-window.tsx
+++ b/components/features/cli/terminal-window.tsx
@@ -21,7 +21,7 @@ export const TerminalWindow = ({
   onExit,
 }: TerminalWindowProps) => {
   return (
-    <div className="h-screen flex flex-col bg-slate-950 text-slate-100 font-mono overflow-hidden relative">
+    <div className="h-full flex flex-col bg-slate-950 text-slate-100 font-mono overflow-hidden relative">
       {/* Exit Button - Top Right */}
       {onExit && (
         <div className="absolute top-4 right-4 z-10">

--- a/components/pages/cli.tsx
+++ b/components/pages/cli.tsx
@@ -83,7 +83,7 @@ export const CLI = () => {
     // Split content by newlines to handle multi-line output
     const contentStr = typeof content === "string" ? content : String(content);
     const lines = contentStr.split("\n");
-    
+
     const outputLines: OutputLine[] = lines.map((lineContent, index) => {
       const isLastLine = index === lines.length - 1;
       return {
@@ -94,7 +94,7 @@ export const CLI = () => {
         isTemporary: isTemporary && isLastLine, // Only mark the last line as temporary
       };
     });
-    
+
     dispatch({ type: "ADD_OUTPUT", payload: outputLines });
   }, []);
 
@@ -301,7 +301,7 @@ export const CLI = () => {
   }, [setIsCLI]);
 
   return (
-    <div className="h-screen">
+    <div className="h-dvh">
       <TerminalWindow
         output={state.output}
         currentDirectory={state.currentDirectory}


### PR DESCRIPTION
- Change terminal window from h-screen to h-full for better parent container sizing
- Update CLI page container from h-screen to h-dvh for dynamic viewport height
- Clean up trailing whitespace
